### PR TITLE
If a Field is hit by a different team the team is not changed [#342]

### DIFF
--- a/src/lib/components/Games/FourWinning.svelte
+++ b/src/lib/components/Games/FourWinning.svelte
@@ -75,6 +75,8 @@
 			} else {
 				// If the cell is already claimed by another team
 				if (cell.style.backgroundColor != currentTeam.color) {
+					FieldClickedFourTimes(outerIndex, innerIndex);
+					changeTeam();
 					open_dialog({
 						text: '<b> Oops! </b> This Field is already claimed by another Team. You can still win by hitting it four times!',
 						modal: false,


### PR DESCRIPTION
## Description

This Pull Request fixes the bu, that after a different Team has hit a claimed fields, the Team is not chaanged.

## Related Issue

[#342]

## Changes Made

List the specific changes made in this pull request, such as added, modified, or deleted files, new features implemented, bugs fixed, etc.

- Change 1: Added changeTeam function before openDialog

## Checklist

Make sure all items on the checklist below are completed before submitting the pull request. Remove any items that are not applicable.

- [x] My code follows the project's coding conventions.
- [x] My changes have been tested locally and pass all necessary tests.
- [x] I have updated the documentation if applicable.
- [x] I have added appropriate comments to my code.
- [x] My changes do not introduce any breaking changes.
- [x] I have tested the changes on different devices/browsers (if applicable).
- [x] I have requested reviews from relevant team members.

## Additional Notes

None
